### PR TITLE
Disable vacuuming on the reports table by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Minor Version 0.13.0
+
+Do not vacuum the reports table after reports GC by default
+  - [PR #2](https://github.com/npwalker/puppetdb_gc/pull/2)
+
 # Minor Version 0.12.0
 
 Adds cronjob for new GC type gc_packages

--- a/manifests/gc_cron.pp
+++ b/manifests/gc_cron.pp
@@ -16,6 +16,7 @@ define puppetdb_gc::gc_cron (
   Optional[Variant[Integer, Array[Integer]]] $cron_hour   = undef,
   Optional[Variant[Integer, Array[Integer]]] $cron_day    = undef,
   String                    $postgresql_host = $puppetdb_host,
+  Boolean                   $vacuum_reports  = false,
 )
 {
 
@@ -29,7 +30,7 @@ define puppetdb_gc::gc_cron (
                       api_version   => $api_version,
                       api_payload   => $api_payload,
                       postgresql_host => $postgresql_host,
-
+                      vacuum_reports => $vacuum_reports,
                     } ),
       user     => 'root',
       minute   => $cron_minute,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -10,6 +10,7 @@ class puppetdb_gc (
                                                          false => 8080,
                                                        },
   String                    $postgresql_host         = $puppetdb_host,
+  Boolean                   $vacuum_reports          = false,
 ) {
 
   Puppetdb_gc::Gc_cron {
@@ -30,6 +31,7 @@ class puppetdb_gc (
 
   puppetdb_gc::gc_cron { 'purge_reports' :
     cron_minute    => [0,15,30,45],
+    vacuum_reports => $vacuum_reports,
   }
 
   puppetdb_gc::gc_cron { 'other' :

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "npwalker/puppetdb_gc",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "author": "npwalker",
   "summary": "A Module for managing your PuppetDB Garbage Collection",
   "license": "Apache-2.0",

--- a/templates/puppetdb_cmd_curl.epp
+++ b/templates/puppetdb_cmd_curl.epp
@@ -5,6 +5,7 @@
       Integer $api_version,
       String  $api_payload,
       String  $postgresql_host,
+      Boolean $vacuum_reports,
 | -%>
 
 <%
@@ -20,12 +21,14 @@
 
   $curl_certs   = "--cert ${cert_path} --key ${privatekey_path} --cacert ${cacert_path}"
 
-  #psql gives an error if the privatekey isn't 600 or more secure so we just flip it to get psql to run and set it back
-  $chmod_600 = "chmod 600 ${privatekey_path}"
-  $vacuum_command = "/opt/puppetlabs/server/bin/psql 'user=pe-puppetdb sslcert=${cert_path}  sslkey=${privatekey_path} sslrootcert=${cacert_path} sslmode=verify-ca' -h ${postgresql_host} -c 'VACUUM VERBOSE reports'"
-  $chmod_640 = "chmod 640 ${privatekey_path}"
+  if $vacuum_reports {
+    #psql gives an error if the privatekey isn't 600 or more secure so we just flip it to get psql to run and set it back
+    $chmod_600 = "chmod 600 ${privatekey_path}"
+    $vacuum_command = "/opt/puppetlabs/server/bin/psql 'user=pe-puppetdb sslcert=${cert_path}  sslkey=${privatekey_path} sslrootcert=${cacert_path} sslmode=verify-ca' -h ${postgresql_host} -c 'VACUUM VERBOSE reports'"
+    $chmod_640 = "chmod 640 ${privatekey_path}"
+  }
 
-  if $api_payload == 'purge_reports' {
+  if $api_payload == 'purge_reports' and $vacuum_reports {
     $final_output = "${curl_command} ${curl_certs}; ${chmod_600}; ${vacuum_command}; ${chmod_640}"
   } else {
     $final_output = "${curl_command} ${curl_certs}"


### PR DESCRIPTION
Prior to this commit, we were vacuuming the reports table after
running GC on reports by default.  However,  if you decided that
running report GC every 5 minutes was the most efficient thing to
do then running a VACUUM after that every 5 minutes probably
wouldn't be very efficient.

After this commit, we default to not vacuuming the report table
after reports GC is completed.