### PR TITLE
Increase the frequency for other and gc_package cron jobs

### DIFF
--- a/manifests/gc_cron.pp
+++ b/manifests/gc_cron.pp
@@ -8,7 +8,7 @@ define puppetdb_gc::gc_cron (
   Enum['absent', 'present'] $gc_cron_ensure               = 'present',
   Boolean                   $use_ssl                      = true,
   String                    $puppetdb_host                = $use_ssl ? {
-                                                              true  => $fqdn,
+                                                              true  => $facts['networking']['fqdn'],
                                                               false => '127.0.0.1',
                                                             },
   Integer                   $puppetdb_port                = $use_ssl ? {
@@ -18,9 +18,9 @@ define puppetdb_gc::gc_cron (
   String                    $api_command                  = 'clean',
   Integer                   $api_version                  = 1,
   String                    $api_payload                  = $title,
-  Optional[Variant[Integer, Array[Integer]]] $cron_minute = undef,
-  Optional[Variant[Integer, Array[Integer]]] $cron_hour   = undef,
-  Optional[Variant[Integer, Array[Integer]]] $cron_day    = undef,
+  Optional[Variant[Integer, Array[Integer], Enum['absent']]] $cron_minute = undef,
+  Optional[Variant[Integer, Array[Integer], Enum['absent']]] $cron_hour   = undef,
+  Optional[Variant[Integer, Array[Integer], Enum['absent']]] $cron_day    = undef,
   String                    $postgresql_host              = $puppetdb_host,
   Boolean                   $vacuum_reports               = false,
 )

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -26,12 +26,12 @@ class puppetdb_gc (
   Hash                      $other_cron              =  {
                                                           cron_minute => 55,
                                                           cron_hour   => 0,
-                                                          cron_day    => 20
+                                                          cron_day    => absent
                                                         },
   Hash                     $gc_packages_cron         =  {
                                                           cron_minute => 50,
                                                           cron_hour   => 0,
-                                                          cron_day    => 10
+                                                          cron_day    => absent
                                                         },
 ) {
 


### PR DESCRIPTION
This PR parameterizes the cron jobs and increases the frequency for the `other` and `gc_package` GC jobs. This will help to keep the table size down for customers that have a high rate of change for unique fact names as well as package turnover. The change is to run these jobs daily instead of monthly.