### PR TITLE
(SUP-2923) Replace unencrypted git protocol in .fixtures.yml

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,5 +1,5 @@
 ---
 fixtures:
   repositories:
-    stdlib: "git://github.com/puppetlabs/puppetlabs-stdlib"
-    cron_core: "git://github.com/puppetlabs/puppetlabs-cron_core"
+    stdlib: 'https://github.com/puppetlabs/puppetlabs-stdlib'
+    cron_core: 'https://github.com/puppetlabs/puppetlabs-cron_core'


### PR DESCRIPTION
# Summary

Per recent changes to [GH security](https://github.blog/2021-09-01-improving-git-protocol-security-github/), updated repo source protocols in `.fixures.yaml`.

# Detailed Description

  * Updated `.fixtures.yaml` to move public repo sources from `git` to `https` protocol.